### PR TITLE
Rutas nuevas en back, admin dashboard casi completo en funciones, sin grafico

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon -L",
-    "test": "mocha -w ./tests/**/*.spec.js"
+    "test": "mocha -w ./tests/**/*.spec.js",
+    "build": "react-scripts build"
   },
   "author": "Henry",
   "license": "ISC",

--- a/api/src/controllers/post.js
+++ b/api/src/controllers/post.js
@@ -1,4 +1,4 @@
-const { Post, Game, User, GameMode } = require('../db.js');
+const { Post, Game, User, GameMode, Genre } = require('../db.js');
 const { Op } = require('sequelize');
 
 async function getPosts(req, res) {
@@ -25,6 +25,15 @@ async function getGameMode (req,res){
     return res.status(200).json(gameMode);
   } catch (error) {
     return res.status(500).json({ error: error.message });
+  }
+}
+const getGenres= async (req, res)=>{
+
+  try {
+    let genre = await Genre.findAll()
+    return res.status(200).json(genre)
+  } catch (error) {
+    return res.status(500).json({error:error.message})
   }
 }
 async function getPostsByUserId(req, res) {
@@ -189,7 +198,8 @@ module.exports = {
   createPost,
   getPostsWithPagination,
   deletePost,
-  getGameMode
+  getGameMode,
+  getGenres
   
 
 };

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -89,6 +89,20 @@ const getUserByEmail = async (req, res) => {
   }
 };
 
+const getAdminUsers = async (req, res) => {
+  const { isAdmin } = req.params;
+  try {
+    const admins = await User.findAll({
+      where: {
+        isAdmin: true 
+      }
+    });
+    res.status(200).json(admins);
+  } catch (error) {
+    return res.status(404).json({ message: "Error searching for Admins" });
+  }
+};
+
 const createUser = async (req, res) => {
   const { name, email, password} = req.body;
   const allUsers = await User.findAll();
@@ -219,6 +233,7 @@ module.exports = {
   getUserById,
   getUserByName,
   getUserByEmail,
+  getAdminUsers,
   createUser,
   updateUser,
   deleteUser,

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -16,6 +16,7 @@ const {
   deletePost,
   getPostsWithPagination,
   getGameMode,
+  getGenres,
 } = require("../controllers/post.js");
 const {
   getFavorites,
@@ -28,6 +29,7 @@ const {
   getUserById,
   getUserByName,
   getUserByEmail,
+  getAdminUsers,
   createUser,
   updateUser,
   deleteUser,
@@ -59,6 +61,9 @@ router.delete("/games/:id", deleteGame);
 // Ruta para obtener juegos con paginación y filtros
 router.get("/games/page", getGamesWithPagination);
 
+//Ruta para obtener generos
+router.get('/games/genres', getGenres)
+
 router.get("/games/mode/", getGameMode);
 // Endpoint para obtener un game por id
 router.get("/games/:id", getGamesById);
@@ -71,6 +76,9 @@ router.post("/games", postGames);
 
 // Endpoint para obtener todos los usuarios
 router.get("/users", getAllUsers);
+
+// //Endopoint para obtener los Administradores
+router.get('/users/admins', getAdminUsers)
 
 // Endpoint para obtener un usuario por id
 router.get("/users/:id", authenticateToken, getUserById);
@@ -91,13 +99,13 @@ router.post(
       .matches(/^(?=.*[!@#$%^&*])(?=.*[A-Z])/)
       .withMessage(
         "Password must contain special characters and uppercase letters"
-      ),
-  ],
-  createUser
-);
-
-// Endpoint para actualizar un usuario
-router.put("/users/:id", updateUser);
+        ),
+      ],
+      createUser
+      );
+      
+      // Endpoint para actualizar un usuario
+      router.put("/users/:id", updateUser);
 
 // Endpoint para eliminar un usuario
 router.delete("/users/:id", deleteUser);
@@ -113,6 +121,7 @@ router.post("/favorite", createFavorite);
 
 // Endpoint para obtener usuarios con paginación y filtros
 router.get("/users/page/:page", getUsersWithPagination); // Ruta para obtener usuarios con paginación y filtros
+
 
 //Endpoint para obtener todos los posts
 router.get("/posts", getPosts);

--- a/client/src/Components/Add Admin/AddAdmin.jsx
+++ b/client/src/Components/Add Admin/AddAdmin.jsx
@@ -1,0 +1,10 @@
+
+
+const AddAdmin=()=>{
+    
+
+
+}
+
+
+export default AddAdmin

--- a/client/src/Components/Delete Admin/Delete Admin.jsx
+++ b/client/src/Components/Delete Admin/Delete Admin.jsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { getAdminUsers, updateUser } from "../../Redux/actions";
+
+const DeleteAdmin = ({ afterDeleteAdmin }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getAdminUsers());
+  }, [dispatch]);
+
+  const adminUsers = useSelector((state) => state.admins);
+
+  const handleDeleteAdmin = (adminId) => {
+    const adminToUpdate = adminUsers.find((admin) => admin.id === adminId);
+    if (adminToUpdate) {
+      const updatedAdmin = {
+        ...adminToUpdate,
+        isAdmin: false,
+      };
+      dispatch(updateUser(adminId, updatedAdmin));
+      afterDeleteAdmin();
+    }
+  };
+
+  return (
+    <div>
+      {adminUsers.map((admin) => {
+        return (
+          <div key={admin.id}>
+            <label htmlFor="Name">{admin.name}</label>{" "}
+            <button onClick={() => handleDeleteAdmin(admin.id)}>
+              Delete admin
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DeleteAdmin;

--- a/client/src/Components/DeleteGame/DeleteGame.jsx
+++ b/client/src/Components/DeleteGame/DeleteGame.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { deleteGame, getAllGames } from "../../Redux/actions"
+
+const DeleteGame = ({handleOnDelete})=>{    
+    const dispatch=useDispatch()
+
+    useEffect(()=>{
+        dispatch(getAllGames())
+    }, [])
+    const allGames=useSelector(state=>state.games)
+
+    const handleButton = (game)=>{
+        const gameId=game.id
+        dispatch(deleteGame(gameId))
+        handleOnDelete()
+    }
+
+
+    return(<div>
+        {allGames.map(game=>{
+            return(
+
+                <div>
+                <ul>
+                    <li>
+                        <label htmlFor="Game name">{game.name}</label><button onClick={()=>handleButton(game)} className='ml-6 text-red-700'> Delete</button>
+                    </li>
+                </ul>
+            </div>
+            )
+        })}
+        
+    </div>)
+}
+
+export default DeleteGame

--- a/client/src/Components/DeleteUser/DeleteUser.jsx
+++ b/client/src/Components/DeleteUser/DeleteUser.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { deleteUser, getUsersWithPagination } from "../../Redux/actions"
+
+const DeleteUser =({afterDelete})=>{
+    const dispatch=useDispatch()
+    const [currentPage, setCurrentPage]=useState(1)
+    
+    
+
+    useEffect(()=>{
+        dispatch(getUsersWithPagination(currentPage))
+    }, [currentPage, dispatch])
+    const pagedUsers=useSelector(state=>state.pageUsers)
+    
+    const inPageUsers=pagedUsers.users
+    
+    const currentUser=useSelector(state=>state.user)
+    
+    const handleNext=()=>{
+        if (currentPage !== pagedUsers.totalPages) {
+            const nextPage = currentPage + 1;
+            setCurrentPage(nextPage);
+          }else{
+            setCurrentPage(1)
+          }
+    }
+
+    const handlePrev=()=>{
+        if (currentPage > 1) {
+            const nextPage = currentPage - 1;
+            setCurrentPage(nextPage);
+          }else{
+            const maxPage=pagedUsers.totalPages
+            setCurrentPage(maxPage)
+          }
+    }
+
+
+    const handleDeleteUser = (userid) => {
+        afterDelete();
+        dispatch(deleteUser(userid));
+      };
+      
+      return (
+        <div>
+            {pagedUsers.totalPages >1 && <div>
+                <button onClick={handlePrev}>{'<'}</button>
+                <button onClick={handleNext}>{'>'}</button>
+                </div>}
+          {inPageUsers?.map((user) => {
+            return (
+              <div key={user.id}>
+                <label htmlFor="name">{user.name}</label>
+                {user.id!== currentUser.id &&<button onClick={() => handleDeleteUser(user.id)}>Delete User</button>}
+              </div>
+            );
+          })}
+        </div>
+      );
+}
+
+export default DeleteUser

--- a/client/src/Components/GamesBar/GamesBar.jsx
+++ b/client/src/Components/GamesBar/GamesBar.jsx
@@ -33,13 +33,11 @@ const ImagePreloader = ({ src }) => {
 const GamesBar = () => {
   const dispatch = useDispatch();
 
-  const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
   const [btnUp, setBtnUp] = useState(true);
   const [btnDown, setBtnDown] = useState(false);
 
   useEffect(() => {
-    setLoading(true);
     dispatch(getGamesWithPagination(currentPage));
   }, [currentPage, dispatch]);
 
@@ -65,6 +63,8 @@ const GamesBar = () => {
     if (currentPage !== games.totalPages) {
       const nextPage = currentPage + 1;
       setCurrentPage(nextPage);
+    }else{
+      setCurrentPage(1)
     }
   };
 
@@ -72,6 +72,9 @@ const GamesBar = () => {
     if (currentPage > 1) {
       const nextPage = currentPage - 1;
       setCurrentPage(nextPage);
+    }else{
+      const maxPage=games.totalPages
+      setCurrentPage(maxPage)
     }
   };
 

--- a/client/src/Components/NavBar/NavBar.jsx
+++ b/client/src/Components/NavBar/NavBar.jsx
@@ -137,14 +137,16 @@ const NavBar = () => {
                   onClick={handleProfileClick} 
                 />
                 </li>
-                <li>
+                
 
-                <ProfileItem 
+                {isAdmin && <div>
+                  <li><ProfileItem 
                   href={'/admindashboard'} 
                   text="Dashboard"
-                  onClick={handleProfileClick} 
+                  onClick={handleAdminDash} 
                   />
                   </li>
+                  </div>}
                 <li>
                   <ProfileItem text="Log Out" onClick={handleLogout} />
                 </li>

--- a/client/src/Components/NewGame/NewGame.jsx
+++ b/client/src/Components/NewGame/NewGame.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { getGenres, getGameModes, postGames } from "../../Redux/actions"
+
+const NewGame = ({handleOnNewGame})=>{
+    const dispatch=useDispatch()
+    let z=1
+    let x=1
+    
+    const [genres, setGenres] = useState([])
+    const [gameModes, setGameModes]= useState([])
+    const [error, setError]=useState({
+        name:''
+    })
+
+    const [data, setData] = useState({
+        name: '',
+        thumbnail:'',
+        genre:[],
+        gameMode:[]
+    })
+    
+    useEffect(()=>{
+        dispatch(getGenres())
+        dispatch(getGameModes())
+    }, [])
+
+
+    const allGenres=useSelector(state=>state.genre)
+    const allGameModes=useSelector(state=>state.gameMode)
+
+    const handleOnChange=(event)=>{
+        setData({
+            ...data,
+            [event.target.name]:event.target.value
+        })
+    
+    }
+
+    const handleGameModesChanges = (event)=>{
+        if(event.target.checked){
+            setGameModes([...gameModes, event.target.value])
+            setData({...data, gameModes:[...gameModes, event.target.value]})
+        }else{
+            const updatedGameModes = gameModes.filter(g=>g !== gameModes);
+            setGameModes(updatedGameModes);
+            setData({...data, gameModes:updatedGameModes})
+        }
+    }
+
+    const handleGenresChange= (event)=>{
+        if(event.target.checked){
+            setGenres([...genres, event.target.value])
+            setData({...data, genres:[...genres, event.target.value]})
+        }else{
+            const updatedGenres = gameModes.filter(g=>g !== genres);
+            setGameModes(updatedGenres);
+            setData({...data, genre:updatedGenres})
+        }
+    }
+
+    const handleOnSubmit =(event)=>{
+        event.preventDefault()
+            dispatch(postGames(data))
+            setData({
+                name: '',
+                thumbnail:'',
+                gameModes:[],
+                genres:[]
+            })
+        handleOnNewGame()
+    }
+        
+
+    return (
+        <form key='New Game Form' onSubmit={handleOnSubmit}>
+            <label htmlFor="Name">Game Name</label>
+            <input type="text"
+             placeholder="Introduce a game name"
+             name="name"
+              className="ml-8" value={data.name}
+              onChange={handleOnChange} />
+            <hr />
+            <label htmlFor="thumbnail">Thumbnail</label>
+            <input type="text" placeholder="Introduce an Url"
+            name="thumbnail"
+             value={data.thumbnail}
+             onChange={handleOnChange}
+             />
+            <hr />
+            <label htmlFor="">Game modes</label>
+            <div className="flex flex-row place-content-center">
+
+            {allGameModes.map((gnr)=>(
+                <div>
+                    <ul>
+                        <li>
+                            <input
+                            onChange={handleGameModesChanges}
+                             type="checkbox"
+                             value={gnr.name}
+                             key={'a'+z++}
+                              name="name" />
+                            <label htmlFor={'a'+z++}>{gnr.name}</label>
+                        </li>
+                    </ul>
+                </div>
+            ))}
+            </div>
+            <hr />
+
+            <label htmlFor="">Genres</label>
+            <div style={{display:'grid', gridTemplateColumns:'Repeat(6, 1fr)'}}>
+            {allGenres.map((gnr)=>(
+                <div>
+                    <ul>
+                        <li>
+                            <input type="checkbox" 
+                            onChange={handleGenresChange}
+                            value={gnr.name}
+                            key={'a'+x++} />
+                            <label htmlFor={'a'+x++}>{gnr.name}</label>
+                        </li>
+                    </ul>
+                    
+                </div>
+            ))}
+            </div>
+
+            <hr/>
+            <button type="submit">New Game</button>
+        </form>
+    )
+
+
+}
+
+export default NewGame

--- a/client/src/Redux/action-types.js
+++ b/client/src/Redux/action-types.js
@@ -4,6 +4,7 @@ export const GET_GAME_BY_ID = 'GET_GAME_BY_ID';
 export const POST_GAME = 'POST_GAME';
 export const GET_GAMES_WITH_PAGINATION= 'GET_GAMES_WITH_PAGINATION';
 export const GET_GAMEMODES= 'GAME_GAMEMODES';
+export const GET_GENRES= 'GET_GENRES'
 export const CREATE_USER = 'CREATE_USER';
 export const GET_USER_BY_ID = 'GET_USER_BY_ID';
 export const GET_USER_BY_EMAIL = 'GET_USER_BY_EMAIL';
@@ -21,4 +22,6 @@ export const ORDER='ORDER';
 export const GET_ALL_USERS = 'GET_ALL_USERS';
 export const ADD_FAVORITE = 'ADD_FAVORITE';
 export const DELETE_FAVORITE = 'DELETE_FAVORITE';
-
+export const DELETE_GAME= 'DELETE_GAME'
+export const GET_ADMINS= 'GET_ADMINS'
+export const GET_USERS_WITH_PAGINATION='GET_USERS_WITH_PAGINATION'

--- a/client/src/Redux/actions.js
+++ b/client/src/Redux/actions.js
@@ -1,4 +1,4 @@
-import { async } from "@firebase/util";
+// import { async } from "@firebase/util";
 import axios from "axios";
 import {
 
@@ -9,6 +9,7 @@ import {
     GET_POST_BY_USER_ID,
     DELETE_POST,
     GET_GAME_MODE,
+    GET_GENRES,
     CREATE_USER,
     GET_USER_BY_ID,
     GET_USER_BY_NAME,
@@ -17,17 +18,20 @@ import {
     DELETE_USER,
     UPDATE_USER,
     GET_GAMES_WITH_PAGINATION,
-    GET_ALL_POSTS,
+    GET_USERS_WITH_PAGINATION,
     GET_POST_WITH_PAGINATION,
+    GET_ALL_POSTS,
     CREATE_POST,
     ORDER,
     GET_ALL_USERS,
     ADD_FAVORITE,
     DELETE_FAVORITE,
+    DELETE_GAME,
+    GET_ADMINS,
 
     
 } from './action-types';
-import { ErrorMessage } from 'formik';
+// import { ErrorMessage } from 'formik';
 
 
 export const getAllGames = () => {
@@ -105,6 +109,7 @@ export const getPostsByUserId = (id) => {
     }
   };
 };
+
 export const getPostsWithPagination = (currentPage, gameid, gamemodeid) => {
   return async (dispatch) => {
     try {
@@ -130,6 +135,15 @@ export const getPostsWithPagination = (currentPage, gameid, gamemodeid) => {
     }
   };
 };
+export const getUsersWithPagination=(currentPage)=>{
+  return async(dispatch)=>{
+    const userPaginated= await axios.get(`http://localhost:3001/users/page/${currentPage}`)
+    return dispatch({
+      type:GET_USERS_WITH_PAGINATION,
+      payload: userPaginated.data
+    })
+  }
+}
 export const getAllPosts = () => {
   return async (dispatch) => {
     try {
@@ -147,8 +161,8 @@ export const getAllPosts = () => {
 export const deletePost = (payload) => {
   return async (dispatch) => {
     try {
-      let newGame = await axios.post(
-        "http://localhost:3001/games/delete",
+      let newGame = await axios.delete(
+        "http://localhost:3001/post",
         payload
       );
       return dispatch({
@@ -160,7 +174,7 @@ export const deletePost = (payload) => {
     }
   };
 };
-export const gameMode = () => {
+export const getGameModes = () => {
   return async (dispatch) => {
     try {
       let newGame = await axios.get("http://localhost:3001/games/mode");
@@ -173,6 +187,19 @@ export const gameMode = () => {
     }
   };
 };
+export const getGenres = ()=>{
+  return async (dispatch)=>{
+    try {
+      let genres= await axios.get('http://localhost:3001/games/genres')
+      return dispatch({
+        type: GET_GENRES,
+        payload:genres.data
+      })
+    } catch (error) {
+        throw new Error(error)
+    }
+  }
+}
 export const createUser = (payload) => {
   return async (dispatch) => {
     try {
@@ -230,6 +257,21 @@ export const getUserByEmail = (email) => async (dispatch) => {
   }
 };
 
+export const getAdminUsers= ()=>{
+  return async(dispatch)=>{
+    try {
+      const admins=await axios.get('http://localhost:3001/users/admins')
+      return dispatch({
+        type:GET_ADMINS,
+        payload:admins.data
+      })      
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+}
+
+
 export const logIn = (payload) => async (dispatch) => {
   try {
     const response = await axios.post("http://localhost:3001/login", payload);
@@ -256,7 +298,7 @@ export const logOut = () => async (dispatch) => {
 
 export const deleteUser = (id) => async (dispatch) => {
   try {
-    const userId = await axios(`http://localhost:3001/users/${id}`);
+    const userId = await axios.delete(`http://localhost:3001/users/${id}`);
     return dispatch({
       type: DELETE_USER,
       payload: userId.data,
@@ -334,6 +376,21 @@ export const getAllUsers = () => async (dispatch) => {
     throw new Error(error);
   }
 };
+
+export const deleteGame=(id)=>{
+  return async(dispatch)=>{
+    try {
+      const gameId = await axios.delete(`http://localhost:3001/games/${id}`);
+      return dispatch({
+        type: DELETE_GAME,
+        payload: gameId.data,
+      });
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+  
+}
 
 
 

--- a/client/src/Redux/actions.js
+++ b/client/src/Redux/actions.js
@@ -30,7 +30,7 @@ import {
     DELETE_FAVORITE,
     DELETE_GAME,
     GET_ADMINS,
-
+}from './action-types'
 
 export const getAllGames = () => {
   return async (dispatch) => {

--- a/client/src/Redux/reducer.js
+++ b/client/src/Redux/reducer.js
@@ -2,10 +2,11 @@ import {
   GET_ALL_GAMES,
   GET_GAMES_BY_NAME,
   GET_GAME_BY_ID,
-  // POST_GAME,
+  POST_GAME,
   GET_USER_BY_ID,
   GET_USER_BY_NAME,
   GET_USER_BY_EMAIL,
+  GET_ADMINS,
   CREATE_USER,
   LOG_OUT,
   DELETE_USER,
@@ -20,22 +21,29 @@ import {
   GET_ALL_USERS,
   ADD_FAVORITE,
   DELETE_FAVORITE,
-  
+  GET_GENRES,
+  DELETE_GAME,
+  GET_USERS_WITH_PAGINATION,
 } from "./action-types";
 
 const initialState = {
+  admins:[],
   games: [],
   game: [],
   gameMode: [],
+  genre:[],
+  myFavorites: [],
   pageGames: [],
   posts: [],
   pagePosts: [],
-  userPosts: [],
-  user: localStorage.getItem("user")
-    ? JSON.parse(localStorage.getItem("user"))
-    : [],
+  pageUsers:[],
   otherUser: [],
-  myFavorites: [],
+  user: localStorage.getItem("user")
+  ? JSON.parse(localStorage.getItem("user"))
+  : [],
+  users:[],
+  userPosts: [],
+
 };
 
 const reducer = (state = initialState, action) => {
@@ -74,13 +82,18 @@ const reducer = (state = initialState, action) => {
     case GET_USER_BY_NAME:
       return {
         ...state,
-        user: action.payload,
+        users: action.payload,
       };
     case GET_USER_BY_EMAIL:
       return {
         ...state,
         user: action.payload,
       };
+    case GET_ADMINS:
+      return {
+        ...state,
+        admins:action.payload
+      }
     case LOG_OUT:
       return {
         ...state,
@@ -91,6 +104,11 @@ const reducer = (state = initialState, action) => {
         ...state,
         user: action.payload,
       };
+    case DELETE_GAME:
+      return{
+        ...state,
+        user:action.payload
+      }
     case UPDATE_USER:
       return {
         ...state,
@@ -116,6 +134,11 @@ const reducer = (state = initialState, action) => {
         ...state,
         pagePosts: action.payload,
       };
+    case GET_USERS_WITH_PAGINATION:
+      return{
+        ...state,
+        pageUsers:action.payload
+      }
     case CREATE_POST:
       return {
         ...state,
@@ -152,6 +175,16 @@ const reducer = (state = initialState, action) => {
           (favorite) => favorite.id !== action.payload.id
         ),
       };
+    case POST_GAME:
+      return{
+        ...state,
+        games:[...state.games, ...action.payload]
+      }
+    case GET_GENRES:
+      return{
+        ...state,
+        genre:action.payload
+      }
     default:
       return {
         ...state,

--- a/client/src/Views/AdminDashboard/AdminDashboard.jsx
+++ b/client/src/Views/AdminDashboard/AdminDashboard.jsx
@@ -1,19 +1,119 @@
-import { useSelector } from "react-redux"
-import { useNavigate } from "react-router-dom"
+import { useState } from "react"
+import AddAdmin from "../../Components/Add Admin/AddAdmin"
+import DeleteGame from "../../Components/DeleteGame/DeleteGame"
+import DeleteUser from "../../Components/DeleteUser/DeleteUser"
+import NewGame from "../../Components/NewGame/NewGame"
+import DeleteAdmin from "../../Components/Delete Admin/Delete Admin"
+
 
 const AdminDashboard = ()=>{
+    const [show, setShow] = useState(false)
+    const [showD, setShowD]=useState(false)
+    const [showU, setShowU]=useState(false)
+    const [showM, setShowM]=useState(false)
+    const [showA, setShowA]=useState(false)
 
 
+    const handleNewGame=()=>{
+       if(!show) setShow(true)
+       if(show) setShow(false)
+       if(showD || showM || showU || showA){ 
+        setShowD(false)
+        setShowU(false)
+        setShowM(false)
+        setShowA(false)
+    }
+    }
+    const handleOnNewGame= ()=>{
+        setShow(false)
+    }
+    const handleDeleteGame=()=>{
+        if(!showD) setShowD(true)
+        if(showD)setShowD(false)
+        if(show || showM || showU || showA){ 
+            setShow (false)
+            setShowU(false)
+            setShowM(false)
+            setShowA(false)
+        }
+    }
+
+    const handleOnDelete=()=>{
+        setShowD(false)
+    }
+
+    const handleAddAdmin=()=>{
+        if(!showM) setShowM(true)
+        if(showM)setShowM(false)
+        if(show || showD|| showU || showA){ 
+            setShow (false)
+            setShowU(false)
+            setShowD(false)
+            setShowA(false)
+        }
+    }
+
+    const handleAddedAdmin=()=>{
+        setShowM(false)
+    }
+    const handleDeleteUser=()=>{
+        if(!showU) setShowU(true)
+        if(showU)setShowU(false)
+        if(show || showD|| showM || showA){ 
+            setShow (false)
+            setShowM(false)
+            setShowD(false)
+            setShowA(false)
+        }
+    }
+
+    const afterDelete=()=>{
+        setShowU(false)
+    }
     
+    const handleDeleteAdmin=()=>{
+        if(!showA) setShowA(true)
+        if(showA)setShowA(false)
+        if(show || showD|| showM || showU){ 
+            setShow (false)
+            setShowM(false)
+            setShowD(false)
+            setShowU(false)
+        }
+    }
+    const afterDeleteAdmin=()=>{
+        setShowA(false)
+    }
+  
     return(<div>
-        <div>
+        <div className="mb-4">
             <h1>Imagen con posteos favoritos/juegos mas jugados</h1>
         </div>
-        <button>New Game</button>
-        <button>Delete Game</button>
-        <button>Modify Admin</button>
-        <button>Delete an User</button>
-    </div>)
+        <div>
+            <button className="ml-4 mr-4 cursor-pointer" onClick={handleNewGame}><h1>New Game</h1></button>
+            <button className="ml-4 mr-4 cursor-pointer" value='Del game' onClick={handleDeleteGame}>Delete Game</button>
+            <button className="ml-4 mr-4 cursor-pointer" value='Mod Admin' onClick={handleAddAdmin}>Add Admin</button>
+            <button className="ml-4 mr-4 cursor-pointer" value='Del User' onClick={handleDeleteAdmin}>Delete an admin</button>
+            <button className="ml-4 mr-4 cursor-pointer" value='Del User' onClick={handleDeleteUser}>Delete an User</button>
+            
+        </div>
+        <div>
+        {show && <div><NewGame handleOnNewGame={handleOnNewGame} /> <button onClick={()=>setShow(false)}>Cancel</button></div>
+    } 
+    </div>  
+        {showD && <div><button onClick={()=>setShowD(false)} className='text-red-700'>Cancel</button><DeleteGame handleOnDelete={handleOnDelete} /></div>} 
+    <div>
+        {showM && <div><button onClick={()=>setShowM(false)}>Cancel</button><AddAdmin handleAddedAdmin={handleAddedAdmin} /></div>}
+    </div>
+    <div> 
+        {showA && <div><button onClick={()=>setShowA(false)}>Cancel</button><DeleteAdmin afterDeleteAdmin={afterDeleteAdmin} /></div>}
+    </div>
+    <div>
+        {showU && <div><button onClick={()=>setShowU(false)}>Cancel</button><DeleteUser afterDelete={afterDelete} /></div>}
+    </div>
+
+    </div>
+    )
 }
 
 export default AdminDashboard


### PR DESCRIPTION
Rutas del back:
get genres: Para recuperar los generos del modelo que hacemos cuando copiamos los juegos en la db.
get admins:recupera los usuarios que tienen isAdmin en true.

Front: Componente dashboard sin estilos, ni los charts para mostrar % de juegos/respuestas o lo mas vendido/comprado,
El dashboard tiene otros 5 componentes hijos que nos permiten manejar la pagina:
Add games: para añadir un juego a la db, hay un error que no toma generos o modo de juegos, hay que revisar el back para esto.
Delete games: borra un juego de la base de datos.
Add admin: esta vacio en este preciso momento, pero deberia modificar el isAdmin a "true"
Delete Admin:tiene un bug que cambia la cuenta logeada, sin embargo deberia permitir a un admin cambiar el estado de un admin "x" a  false, es decir isAdmin:false(esta tambien en un futuro podemos hacer que sea fijo a quien no se puede borrar)
Delete User: borrado logico de un usuario de la db